### PR TITLE
Feat: Add keyboard shortcuts for click actions

### DIFF
--- a/background.js
+++ b/background.js
@@ -292,3 +292,36 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     showBadgeText('⚠️', true);
   }
 });
+
+/**
+ * Event listener for keyboard shortcuts
+ * Handles defined commands to trigger corresponding click actions
+ * @param {string} command - The name of the command that was triggered
+ * @description
+ * - _execute_action (Cmd+Shift+1): Performs single-click action
+ * - double_click_action (Cmd+Shift+2): Performs double-click action
+ * - triple_click_action (Cmd+Shift+3): Performs triple-click action
+ */
+chrome.commands.onCommand.addListener(async (command) => {
+  // Get the current active tab
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+  if (!tab || !tab.id) {
+    console.warn('No active tab found for command:', command);
+    return;
+  }
+
+  switch (command) {
+    case '_execute_action': // Corresponds to Command+Shift+1
+      await performSingleClickAction(tab);
+      break;
+    case 'double_click_action': // Corresponds to Command+Shift+2
+      await performDoubleClickAction(tab);
+      break;
+    case 'triple_click_action': // Corresponds to Command+Shift+3
+      await performTripleClickAction(tab);
+      break;
+    default:
+      console.warn('Unknown command received:', command);
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -7,10 +7,34 @@
     "activeTab",
     "scripting",
     "clipboardWrite",
-    "storage"
+    "storage",
+    "commands"
   ],
   "action": {
     "default_title": "Copy title and URL to clipboard"
+  },
+  "commands": {
+    "_execute_action": {
+      "suggested_key": {
+        "default": "MacCtrl+Shift+1",
+        "mac": "Command+Shift+1"
+      },
+      "description": "Perform single-click action"
+    },
+    "double_click_action": {
+      "suggested_key": {
+        "default": "MacCtrl+Shift+2",
+        "mac": "Command+Shift+2"
+      },
+      "description": "Perform double-click action"
+    },
+    "triple_click_action": {
+      "suggested_key": {
+        "default": "MacCtrl+Shift+3",
+        "mac": "Command+Shift+3"
+      },
+      "description": "Perform triple-click action"
+    }
   },
   "background": {
     "service_worker": "background.js"

--- a/options.html
+++ b/options.html
@@ -341,7 +341,19 @@
         <li><strong>Launch macOS Shortcuts:</strong> <code class="clickable"
             data-copy="shortcuts://run-shortcut?name=Test&input=foo"
             title="Click to copy">shortcuts://run-shortcut?name=Test&input=foo</code></li>
-      </ul>:
+      </ul>
+    </div>
+
+    <div class="variables">
+      <h4>Keyboard Shortcuts:</h4>
+      <ul>
+        <li><strong>Single-click action:</strong> <code title="Command+Shift+1 on macOS, Ctrl+Shift+1 on other platforms">Cmd/Ctrl+Shift+1</code></li>
+        <li><strong>Double-click action:</strong> <code title="Command+Shift+2 on macOS, Ctrl+Shift+2 on other platforms">Cmd/Ctrl+Shift+2</code></li>
+        <li><strong>Triple-click action:</strong> <code title="Command+Shift+3 on macOS, Ctrl+Shift+3 on other platforms">Cmd/Ctrl+Shift+3</code></li>
+      </ul>
+      <p style="font-size: 13px; color: var(--info-text);">
+        <em>Note: You can customize these shortcuts by visiting <code style="font-size: 12px;">chrome://extensions/shortcuts</code></em>
+      p>
     </div>
 
     <form id="optionsForm">


### PR DESCRIPTION
- Implement keyboard shortcuts to trigger single, double, and triple click actions.
  - Cmd/Ctrl+Shift+1: Single-click action
  - Cmd/Ctrl+Shift+2: Double-click action
  - Cmd/Ctrl+Shift+3: Triple-click action
- Added `commands` permission to `manifest.json` and defined the shortcuts.
- Updated `background.js` to listen for and handle these commands.
- Updated `options.html` to display the new keyboard shortcuts and inform users how to customize them via chrome://extensions/shortcuts.