### PR TITLE
Fix: Ensure user-typed \n and default \n in format strings create newlines

### DIFF
--- a/background.js
+++ b/background.js
@@ -118,7 +118,10 @@ async function performClickAction(tab, clickType) {
   try {
     const result = await chrome.storage.sync.get(FALLBACK_FORMATS);
     const formatKey = `${clickType}ClickFormat`;
-    const format = result[formatKey] || FALLBACK_FORMATS[formatKey] || '';
+    let format = result[formatKey] || FALLBACK_FORMATS[formatKey] || '';
+
+    // Replace literal '\n' (from user input) with actual newline characters
+    format = format.replace(/\\n/g, '\n');
 
     // Auto-detect action based on format template
     const isUrlAction = isUrlFormat(format);

--- a/options.js
+++ b/options.js
@@ -10,7 +10,7 @@
  */
 const DEFAULT_FORMATS = {
   // Format templates (action is auto-detected based on URL scheme)
-  singleClickFormat: '<title>\\n<url>', // Maintained original default
+  singleClickFormat: '<title>\n<url>', // Maintained original default
   doubleClickFormat: '[<title>](<url>)', // Maintained original default
   tripleClickFormat: '<title>', // Maintained original default
 };


### PR DESCRIPTION
- Modified options.js so the default format string for single-click uses an actual newline character (`\n`) instead of a literal `\\n`.
- Modified background.js to process format strings by replacing any user-typed literal `\n` sequences with actual newline characters before substitutions are made.

This ensures that both the default configuration and user-customized formats with `\n` will correctly produce newlines in the copied output.