### PR TITLE
Feat: Replace format textareas with dropdowns and custom option

### DIFF
--- a/options.html
+++ b/options.html
@@ -133,27 +133,35 @@
         </div>
         <form id="optionsForm">
           <div class="space-y-8">
+            <!-- Single Click -->
             <div>
-              <label class="block text-lg font-medium text-gray-800 dark:text-slate-200 mb-2" for="single-click">Single
-                Click</label>
-              <textarea
-                class="w-full p-4 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out font-mono text-sm shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500"
-                id="single-click" name="singleClickFormat" rows="3" placeholder="<title>\n<url>"></textarea>
+              <label class="block text-lg font-medium text-gray-800 dark:text-slate-200 mb-2" for="single-click-type">Single Click</label>
+              <select id="single-click-type" name="singleClickFormatType" class="w-full p-3 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 mb-2">
+                <!-- Options will be populated by JS, but we can put them here for SSR/no-JS fallback -->
+              </select>
+              <textarea id="single-click-custom-format" name="singleClickCustomFormat" rows="3" placeholder="Enter custom format..." class="w-full p-4 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out font-mono text-sm shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500" style="display: none;"></textarea>
+              <!-- Hidden textarea to store the actual format string, to be used by background script. This simplifies storage logic. -->
+              <textarea id="single-click-format" name="singleClickFormat" class="hidden" rows="1"></textarea>
             </div>
+
+            <!-- Double Click -->
             <div>
-              <label class="block text-lg font-medium text-gray-800 dark:text-slate-200 mb-2" for="double-click">Double
-                Click</label>
-              <textarea
-                class="w-full p-4 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out font-mono text-sm shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500"
-                id="double-click" name="doubleClickFormat" rows="3" placeholder="[<title>](<url>)"></textarea>
+              <label class="block text-lg font-medium text-gray-800 dark:text-slate-200 mb-2" for="double-click-type">Double Click</label>
+              <select id="double-click-type" name="doubleClickFormatType" class="w-full p-3 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 mb-2">
+                <!-- Options will be populated by JS -->
+              </select>
+              <textarea id="double-click-custom-format" name="doubleClickCustomFormat" rows="3" placeholder="Enter custom format..." class="w-full p-4 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out font-mono text-sm shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500" style="display: none;"></textarea>
+              <textarea id="double-click-format" name="doubleClickFormat" class="hidden" rows="1"></textarea>
             </div>
+
+            <!-- Triple Click -->
             <div>
-              <label class="block text-lg font-medium text-gray-800 dark:text-slate-200 mb-2" for="triple-click">Triple
-                Click</label>
-              <textarea
-                class="w-full p-4 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out font-mono text-sm shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500"
-                id="triple-click" name="tripleClickFormat"
-                rows="3" placeholder="<title>"></textarea>
+              <label class="block text-lg font-medium text-gray-800 dark:text-slate-200 mb-2" for="triple-click-type">Triple Click</label>
+              <select id="triple-click-type" name="tripleClickFormatType" class="w-full p-3 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 mb-2">
+                <!-- Options will be populated by JS -->
+              </select>
+              <textarea id="triple-click-custom-format" name="tripleClickCustomFormat" rows="3" placeholder="Enter custom format..." class="w-full p-4 border border-gray-300 dark:border-slate-600 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 dark:focus:ring-blue-400 dark:focus:border-blue-400 transition duration-150 ease-in-out font-mono text-sm shadow-sm bg-white dark:bg-slate-700 text-gray-900 dark:text-slate-100 placeholder-gray-400 dark:placeholder-slate-500" style="display: none;"></textarea>
+              <textarea id="triple-click-format" name="tripleClickFormat" class="hidden" rows="1"></textarea>
             </div>
           </div>
           <div class="mt-10 pt-6 border-t border-gray-200 dark:border-slate-700 flex flex-wrap gap-4 justify-end">


### PR DESCRIPTION
- Modified options.html to replace existing textareas for click format settings with select dropdowns offering predefined formats and a 'Custom Format' option.
- A textarea for custom format input is now dynamically shown/hidden based on the dropdown selection.
- Updated options.js to manage the new UI elements:
  - Populates dropdowns with predefined formats.
  - Handles visibility of the custom format textarea.
  - Loads and saves both the selected format type (e.g., 'markdown', 'custom') and the actual format string to chrome.storage.sync.
  - Ensures the core format storage keys (e.g., `singleClickFormat`) always contain the ready-to-use format string for the background script.
  - Updated reset functionality to correctly handle new dropdowns.
  - Enhanced export/import to include format type information and maintain compatibility with older import files.