### PR TITLE
Feat: Make <title> and <url> in options page clickable

### DIFF
--- a/options.html
+++ b/options.html
@@ -55,11 +55,11 @@
           </h2>
           <ul class="space-y-2 text-gray-600 dark:text-slate-300">
             <li class="flex items-center">
-              <code class="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 font-mono px-2 py-1 rounded-md text-sm">&lt;title&gt;</code>
+              <code class="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 font-mono px-2 py-1 rounded-md text-sm clickable" data-copy="<title>">&lt;title&gt;</code>
               <span class="ml-2">- The page title</span>
             </li>
             <li class="flex items-center">
-              <code class="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 font-mono px-2 py-1 rounded-md text-sm">&lt;url&gt;</code>
+              <code class="bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 font-mono px-2 py-1 rounded-md text-sm clickable" data-copy="<url>">&lt;url&gt;</code>
               <span class="ml-2">- The page URL</span>
             </li>
             <li class="flex items-center">


### PR DESCRIPTION
Added the 'clickable' class and 'data-copy' attribute to the <code> elements for <title> and <url> in the 'Available Variables' section of options.html.

This allows users to click on these variables to copy their literal string values (e.g., "<title>") to the clipboard, consistent with the existing behavior for the <quote> variable.

The existing JavaScript in options.js handles this functionality without requiring modification.