### PR TITLE
feat: Add <screenshot> template and options

### DIFF
--- a/options.js
+++ b/options.js
@@ -17,6 +17,7 @@ const PREDEFINED_FORMATS = {
   title_url_2_lines: { name: 'Title and URL (2 lines)', value: '<title>\n<url>' },
   title_url_1_line: { name: 'Title and URL (1 line)', value: '<title> - <url>' },
   markdown: { name: 'Markdown', value: '[<title>](<url>)' },
+  screenshot: { name: 'Screenshot', value: '<screenshot>' }, // Added Screenshot option
   custom: { name: 'Custom Format', value: '' }, // Custom value will be from textarea
 };
 


### PR DESCRIPTION
- Adds a new format template `<screenshot>` which captures the current tab's visible content and copies it to the clipboard as an image.
- Adds a "Screenshot" predefined format option in the extension's settings page.
- The `<screenshot>` variable is not displayed in the "Available Variables" section to avoid confusion, as it's a standalone format.
- Refactors text copying to `copyTextToClipboard` and introduces `captureAndCopyScreenshot` for image handling in `background.js`.