### PR TITLE
Add <all_urls> to host_permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,9 @@
     "storage",
     "tabs"
   ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "action": {
     "default_title": "Copy title and URL to clipboard"
   },


### PR DESCRIPTION
This change adds the `<all_urls>` permission to the `host_permissions` array in the `manifest.json` file.

This is to resolve an issue where the extension failed to copy tab information from certain URLs due to missing host permissions.